### PR TITLE
Add missing newlines after "Color Reference"

### DIFF
--- a/data/section-templates-en_EN.js
+++ b/data/section-templates-en_EN.js
@@ -439,6 +439,8 @@ Javascript, HTML, CSS...
 | Example Color | ![#0a192f](https://via.placeholder.com/10/0a192f?text=+) #0a192f |
 | Example Color | ![#f8f8f8](https://via.placeholder.com/10/f8f8f8?text=+) #f8f8f8 |
 | Example Color | ![#00b48a](https://via.placeholder.com/10/00b48a?text=+) #00b48a |
-| Example Color | ![#00d1a0](https://via.placeholder.com/10/00b48a?text=+) #00d1a0 | `,
+| Example Color | ![#00d1a0](https://via.placeholder.com/10/00b48a?text=+) #00d1a0 |
+
+`,
   },
 ]


### PR DESCRIPTION
All new headlines after "Color Reference" are broken (part of the table) without newlines at the end of the table.

![image](https://user-images.githubusercontent.com/1798101/125172926-9253d180-e1bc-11eb-91cf-e626b052ab3a.png)
