### PR TITLE
Implemented caching mechanism

### DIFF
--- a/components/EditorColumn.js
+++ b/components/EditorColumn.js
@@ -1,6 +1,7 @@
 import { useTranslation } from 'next-i18next'
-import { useEffect, useState, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import useDeviceDetect from '../hooks/useDeviceDetect'
+import useLocalStorage from '../hooks/useLocalStorage'
 
 export const EditorColumn = ({
   focusedSectionSlug,
@@ -13,10 +14,12 @@ export const EditorColumn = ({
     const section = templates.find((s) => s.slug === focusedSectionSlug)
     return section ? section.markdown : ''
   }
+
   const [markdown, setMarkdown] = useState(getMarkdown())
   const [isFocused, setFocus] = useState(false)
   const { isMobile } = useDeviceDetect()
   const [MonacoEditor, setMonacoEditor] = useState(null)
+  const { saveBackup } = useLocalStorage()
 
   const monacoEditorRef = useRef(null)
   const textEditorRef = useRef(null)
@@ -24,18 +27,18 @@ export const EditorColumn = ({
   useEffect(() => {
     const markdown = getMarkdown()
     setMarkdown(markdown)
-  }, [focusedSectionSlug])
+  }, [focusedSectionSlug, templates])
 
   const onEdit = (val) => {
     setMarkdown(val)
-    setTemplates((prev) => {
-      return prev.map((template) => {
-        if (template.slug === focusedSectionSlug) {
-          return { ...template, markdown: val }
-        }
-        return template
-      })
+    const newTemplates = templates.map((template) => {
+      if (template.slug === focusedSectionSlug) {
+        return { ...template, markdown: val }
+      }
+      return template
     })
+    setTemplates(newTemplates)
+    saveBackup(newTemplates)
   }
 
   const editorHasFocus = () => {

--- a/components/SectionsColumn.js
+++ b/components/SectionsColumn.js
@@ -9,10 +9,10 @@ import {
 } from '@dnd-kit/core'
 import { restrictToVerticalAxis } from '@dnd-kit/modifiers'
 import { arrayMove, SortableContext, sortableKeyboardCoordinates } from '@dnd-kit/sortable'
-
-import { SortableItem } from './SortableItem'
 import { useTranslation } from 'next-i18next'
 import { useEffect, useState } from 'react'
+import useLocalStorage from '../hooks/useLocalStorage'
+import { SortableItem } from './SortableItem'
 
 export const SectionsColumn = ({
   selectedSectionSlugs,
@@ -21,6 +21,8 @@ export const SectionsColumn = ({
   setSectionSlugs,
   setFocusedSectionSlug,
   focusedSectionSlug,
+  originalTemplate,
+  setTemplates,
   getTemplate,
 }) => {
   const sensors = useSensors(
@@ -35,6 +37,7 @@ export const SectionsColumn = ({
   const [addAction, setAddAction] = useState(false)
   const [currentSlugList, setCurrentSlugList] = useState([])
   const [slugsFromPreviousSession, setSlugsFromPreviousSession] = useState([])
+  const { deleteBackup } = useLocalStorage()
 
   useEffect(() => {
     var slugsFromPreviousSession =
@@ -101,10 +104,13 @@ export const SectionsColumn = ({
     )
     if (sectionResetConfirmed === true) {
       const slugList = data ? data.split(',') : []
+
       setSectionSlugs((prev) => [...prev, ...slugList].filter((s) => s !== 'title-and-description'))
       setSelectedSectionSlugs(['title-and-description'])
       setFocusedSectionSlug('title-and-description')
       localStorage.setItem('current-focused-slug', 'noEdit')
+      setTemplates(originalTemplate)
+      deleteBackup()
     }
   }
 

--- a/hooks/useLocalStorage.js
+++ b/hooks/useLocalStorage.js
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react'
+
+export default function useLocalStorage() {
+  const [backup, setBackup] = useState(null)
+  const [timer, setTimer] = useState(null)
+
+  useEffect(() => {
+    const localBackup = localStorage.getItem('readme-backup')
+
+    if (localBackup) {
+      setBackup(JSON.parse(localBackup))
+    }
+  }, [])
+
+  const saveBackup = (templates) => {
+    try {
+      if (timer) {
+        clearTimeout(timer)
+      }
+
+      setTimer(
+        setTimeout(() => {
+          localStorage.setItem('readme-backup', JSON.stringify(templates))
+        }, 1000)
+      )
+    } catch (_) {
+      console.error('Failed to create local backup')
+    }
+  }
+
+  const deleteBackup = () => {
+    try {
+      localStorage.removeItem('readme-backup')
+    } catch (_) {
+      console.error('Failed to delete local backup')
+    }
+  }
+
+  return { backup, saveBackup, deleteBackup }
+}

--- a/pages/editor.js
+++ b/pages/editor.js
@@ -1,12 +1,12 @@
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import Head from 'next/head'
 import { useEffect, useState } from 'react'
-
 import { DownloadModal } from '../components/DownloadModal'
+import EditPreviewContainer from '../components/EditPreviewContainer'
 import { Nav } from '../components/Nav'
 import { SectionsColumn } from '../components/SectionsColumn'
 import sectionTemplates from '../data/index'
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
-import EditPreviewContainer from '../components/EditPreviewContainer'
+import useLocalStorage from '../hooks/useLocalStorage'
 
 export default function Editor({ sectionTemplate }) {
   const [selectedSectionSlugs, setSelectedSectionSlugs] = useState([])
@@ -15,6 +15,13 @@ export default function Editor({ sectionTemplate }) {
   const [showModal, setShowModal] = useState(false)
   const [templates, setTemplates] = useState(sectionTemplate)
   const [showDrawer, toggleDrawer] = useState(false)
+  const { backup } = useLocalStorage()
+
+  useEffect(() => {
+    if (backup) {
+      setTemplates(backup)
+    }
+  }, [backup])
 
   const getTemplate = (slug) => {
     return templates.find((t) => t.slug === slug)
@@ -77,6 +84,8 @@ export default function Editor({ sectionTemplate }) {
             setSectionSlugs={setSectionSlugs}
             setFocusedSectionSlug={setFocusedSectionSlug}
             focusedSectionSlug={focusedSectionSlug}
+            originalTemplate={sectionTemplate}
+            setTemplates={setTemplates}
             getTemplate={getTemplate}
           />
         </div>


### PR DESCRIPTION
Saves current work to local storage;
Only saves when changes are detected in the editor;
Has 1 second debounce to avoid unnecessary saves (can be changed if it seems too low);
Local storage is cleared when reset button is pressed;
Title section markdown is also set to it's original template when reset is pressed;

Closes #164 