### PR TITLE
Little fixes/refactoring

### DIFF
--- a/components/LanguageDropDown.js
+++ b/components/LanguageDropDown.js
@@ -90,7 +90,7 @@ export function LanguageDropDown({ posts }) {
     <div className="relative inline-block group">
       <button className="inline-flex items-center px-4 py-2 text-gray-800 rounded">
         <span className="mr-1">
-          <img src="language.svg" alt="language selector" className="w-auto h-10 mr-1" />
+          <img src="/language.svg" alt="language selector" className="w-auto h-10 mr-1" />
         </span>
         <svg
           className="w-3 h-4 fill-current"

--- a/components/Nav.js
+++ b/components/Nav.js
@@ -44,7 +44,7 @@ export const Nav = ({
     <nav className="flex justify-between p-4 bg-gray-800 align-center w-full">
       <Link href="/">
         <a className="focus:outline-none focus:ring-2 focus:ring-emerald-400 flex items-center">
-          <img className="w-auto h-12" src="readme.svg" alt="readme.so logo" />
+          <img className="w-auto h-12 text-white" src="/readme.svg" alt="readme.so logo" />
         </a>
       </Link>
       <div className="flex flex-row-reverse md:flex-row">
@@ -59,22 +59,21 @@ export const Nav = ({
             <Menu className="w-10 h-10 md:hidden fill-current text-emerald-500" />
           )}
         </button>
-        {/* visible for md and above */}
-        {focusedSectionSlug !== 'noEdit' && (
-          <button
-            onClick={() => setDarkMode(!darkMode)}
-            aria-label="Color Mode"
-            className="toggle-dark-mode focus:outline-none transition transform motion-reduce:transition-none motion-reduce:transform-none  pr-4"
-          >
-            <Image
-              className="w-auto h-8 mr-2"
-              alt={darkMode ? 'dark' : 'light'}
-              src={darkMode ? '/toggle_sun.svg' : '/toggle_moon.svg'}
-              width={40}
-              height={40}
-            />
-          </button>
-        )}
+
+        <button
+          onClick={() => setDarkMode(!darkMode)}
+          aria-label="Color Mode"
+          className="toggle-dark-mode focus:outline-none transition transform motion-reduce:transition-none motion-reduce:transform-none  pr-4"
+        >
+          <Image
+            title="Theme toggle"
+            className="w-auto h-8 mr-2 text-white"
+            alt={darkMode ? 'dark' : 'light'}
+            src={darkMode ? '/toggle_sun.svg' : '/toggle_moon.svg'}
+            width={40}
+            height={40}
+          />
+        </button>
 
         <button
           type="button"
@@ -82,7 +81,7 @@ export const Nav = ({
           className="flex flex-row relative items-center mr-4 md:mr-0 px-4 py-2 text-sm font-bold tracking-wide text-white border border-transparent rounded-md shadow-sm bg-emerald-500 hover:bg-emerald-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-emerald-500"
           onClick={downloadMarkdownFile}
         >
-          <img className="w-auto h-6 cursor-pointer" src="download.svg" />
+          <img className="w-auto h-6 cursor-pointer" src="/download.svg" />
           <span className="hidden md:inline-block ml-2">{t('nav-download')}</span>
         </button>
       </div>

--- a/components/SortableItem.js
+++ b/components/SortableItem.js
@@ -49,7 +49,7 @@ export function SortableItem(props) {
         className="mr-1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-400"
         {...listeners}
       >
-        <img className="w-5 h-5" src="drag.svg" />
+        <img className="w-5 h-5" src="/drag.svg" />
       </button>
       <p>{props.section.name}</p>
       {props.section.slug === props.focusedSectionSlug && (
@@ -60,7 +60,7 @@ export function SortableItem(props) {
             aria-label="Reset section"
             onClick={onClickReset}
           >
-            <img className="w-auto h-5" src="reset.svg" alt="reset-icon" />
+            <img className="w-auto h-5" src="/reset.svg" alt="reset-icon" />
           </button>
           <button
             className="focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-400 absolute right-2"
@@ -68,7 +68,7 @@ export function SortableItem(props) {
             aria-label="Delete section"
             onClick={onClickTrash}
           >
-            <img className="w-auto h-5" src="trash.svg" alt="trash-icon" />
+            <img className="w-auto h-5" src="/trash.svg" alt="trash-icon" />
           </button>
         </>
       )}

--- a/hooks/useDarkMode.js
+++ b/hooks/useDarkMode.js
@@ -1,28 +1,33 @@
 import { useState, useEffect } from 'react'
 
-const isBrowser = typeof window !== 'undefined'
-
 export default function useDarkMode() {
-  // Define the localstorage key
-  const storageName = 'color-theme'
-  // Get value from localstorage by key
-  const storageTheme = isBrowser ? window.localStorage.getItem(storageName) : 'light'
+  // Define constants
+  const STROAGE_NAME = 'color-theme'
+  const DARK_THEME_CLASS_NAME = 'dark'
+  const LIGHT_THEME_CLASS_NAME = 'light'
+  const DEFAULT_THEME_CLASS_NAME = LIGHT_THEME_CLASS_NAME
 
-  const [enabled, setEnabled] = useState(storageTheme === 'dark')
+  // Create state
+  const [isEnabled, setIsEnabled] = useState(DEFAULT_THEME_CLASS_NAME)
 
-  // Fire off effect that add/removes dark mode class
+  // Once page gets rendered, get theme from stroage
   useEffect(() => {
-    const className = 'dark'
-    const element = window.document.documentElement
-    if (enabled) {
-      localStorage.setItem(storageName, 'dark')
-      element.classList.add(className)
-    } else {
-      localStorage.setItem(storageName, 'light')
-      element.classList.remove(className)
-    }
-  }, [enabled])
+    const themeFromStroage = window.localStorage.getItem(STROAGE_NAME)
+    setIsEnabled(themeFromStroage === DARK_THEME_CLASS_NAME)
+  }, [])
 
-  // Return enabled state and setter
-  return [enabled, setEnabled]
+  // Fire off an effect that adds/removes dark mode class and handles local stroage
+  useEffect(() => {
+    const element = window.document.documentElement
+    if (isEnabled) {
+      localStorage.setItem(STROAGE_NAME, DARK_THEME_CLASS_NAME)
+      element.classList.add(DARK_THEME_CLASS_NAME)
+    } else {
+      localStorage.setItem(STROAGE_NAME, LIGHT_THEME_CLASS_NAME)
+      element.classList.remove(DARK_THEME_CLASS_NAME)
+    }
+  }, [isEnabled])
+
+  // Return isEnabled state and setter
+  return [isEnabled, setIsEnabled]
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -88,9 +88,8 @@ const Home = () => {
                 <Link href="/">
                   <img
                     className="w-auto h-12 cursor-pointer"
-                    src="readme.svg"
+                    src="/readme.svg"
                     alt="readme.so logo"
-                    // style={{ height: '3rem' }}
                   />
                 </Link>
 
@@ -166,7 +165,7 @@ const Home = () => {
                 rel="noopener noreferrer"
                 aria-label="github logo"
               >
-                <img className="w-auto h-6" src="github.svg" alt="github logo" />
+                <img className="w-auto h-6" src="/github.svg" alt="github logo" />
               </a>
             </div>
           </div>


### PR DESCRIPTION
- Theme toggler in navbar also should be visible while not editing md.
- Added title to theme toggler.
- Made navbar image alts' text color white to make them visible.
- In development, images doesn't load when language is not English. Added a '/' to start of image hrefs to fix that.

Saw this error in dev (editor page):

![readme so fixed error](https://user-images.githubusercontent.com/85285027/188506357-3b55d0cc-04c8-4aae-946d-3b21d69e6468.png)


Reason: Since there is no window object in server load, theme is 'light' and editor's theme toggle image's alt is light. But when client page loads, window becomes defined so alt is set to 'dark'. So next throws this error because server and client pages are not same.

Fix: Load theme as light in server, and load the actual theme when page loads (when window gets defined).