### PR TITLE
fix(#247): fix color display of preview column under dark mode

### DIFF
--- a/components/PreviewColumn.js
+++ b/components/PreviewColumn.js
@@ -18,7 +18,7 @@ export const PreviewColumn = ({ selectedSectionSlugs, getTemplate, selectedTab }
   const showPreview = selectedTab === TAB.PREVIEW
   return (
     <div
-      className={`h-full preview-width md:w-auto border border-gray-500 rounded-md p-6 preview bg-white full-screen 
+      className={`h-full preview-width md:w-auto border border-gray-500 rounded-md p-6 preview bg-white dark:bg-black full-screen 
       overflow-x-scroll md:overflow-x-auto ${
         showPreview ? 'overflow-y-scroll' : 'overflow-hidden'
       }`}

--- a/components/RawPreview.js
+++ b/components/RawPreview.js
@@ -57,7 +57,7 @@ export default function RawPreview({ text }) {
       <textarea
         ref={textAreaRef}
         readOnly
-        className="h-full w-full resize-none focus:outline-none"
+        className="h-full w-full resize-none bg-white dark:bg-gray-800 focus:outline-none"
         value={text}
       ></textarea>
     </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -289,6 +289,79 @@ html.dark ::-webkit-scrollbar-thumb:hover {
 }
 
 html.dark .preview {
-  filter: invert(0.9);
+  background-color: rgba(38, 38, 38, var(--tw-bg-opacity));
+  @apply text-white;
   margin-top: -3px;
+}
+
+html.dark .preview h1 {
+  @apply text-white;
+  border-bottom: 1px solid #eaecef;
+}
+
+html.dark .preview h2 {
+  @apply text-white;
+  border-bottom: 1px solid #eaecef;
+}
+
+html.dark .preview h3 {
+  @apply text-white;
+  border-bottom: 1px solid #eaecef;
+}
+
+html.dark .preview h4 {
+  @apply text-white;
+}
+
+html.dark .preview td {
+  @apply text-white;
+  border-color: #a9b0b6;
+}
+
+html.dark .preview th {
+  @apply text-white;
+  border-color: #a9b0b6;
+}
+
+html.dark .preview tr {
+  @apply text-white;
+  background-color: rgba(38, 38, 38, var(--tw-bg-opacity));
+}
+html.dark .preview tr :nth-child(2n) {
+  background-color: rgba(38, 38, 38, var(--tw-bg-opacity));
+}
+
+html.dark .preview table {
+  @apply text-white;
+}
+
+html.dark .preview image {
+  background-color: #fff;
+  color: #3a91e1;
+}
+
+html.dark .preview ul {
+  @apply text-white;
+}
+
+html.dark .preview ul li {
+  @apply text-white;
+}
+
+html.dark .preview ol li {
+  @apply text-white;
+}
+
+html.dark .preview pre {
+  background-color: #6e768166;
+  @apply text-white;
+}
+
+html.dark code:not(.preview pre code) {
+  background-color: #6e768166;
+  @apply text-white;
+}
+
+html.dark .preview a {
+  color: #3a91e1;
 }


### PR DESCRIPTION
CC: @octokatherine 

- remove the usage of `filter: invert`
===

🤔 &nbsp; **Description:**
Regarding issue [#247](https://github.com/octokatherine/readme.so/issues/247), I made changes that were mostly limited to the `/editor` path, specifically the `Preview Column` and `Raw` sections on the right-hand side of the screen.

After removing the css style `filter invert`, I tried to use the currently defined colors as much as possible. I assigned text-related colors such as text-white to `h1`, `h2`, and so on, as well as to `the bullet points in lists`. For the table, I simply removed the background color and did not alternate the column colors for even rows. Instead, I chose to display the table with borders, which is a simpler approach and does not require much color processing.

I tried my best to list all the BEFORE/AFTER combination below so that it might be clear to see the difference.
Hope you will like this change!

🎫 &nbsp; **Related Ticket:**  https://github.com/octokatherine/readme.so/issues/247

✨ &nbsp; **Results:**

![image](https://user-images.githubusercontent.com/23658455/234333045-0d29c90a-ebcb-4748-b700-59c68a286343.png)
![image](https://user-images.githubusercontent.com/23658455/234333253-1692709a-766a-46d1-9554-4c10f662f0fa.png)
![image](https://user-images.githubusercontent.com/23658455/234333414-05c4c242-0cfc-446f-8cf0-39dd0140682e.png)
![image](https://user-images.githubusercontent.com/23658455/234333477-e8e01fc2-f838-4809-95ce-9b951013c761.png)
![image](https://user-images.githubusercontent.com/23658455/234333539-a4c36482-37f4-4716-832d-3a263615662d.png)
![image](https://user-images.githubusercontent.com/23658455/234333671-511284ad-0676-47f0-a7eb-96951d0c1ddc.png)
![image](https://user-images.githubusercontent.com/23658455/234333817-c5622b11-eb64-4534-9ffc-0cbb73d38ff5.png)
![image](https://user-images.githubusercontent.com/23658455/234333895-f9a21a99-8dad-4b98-9e5c-d1aabd67d287.png)

