### PR TITLE
[Fix]: Screenshot in home page not rendered

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -152,6 +152,8 @@ const Home = () => {
                 className="relative rounded-lg shadow-lg"
                 src="/screenshot.png"
                 alt="App screenshot"
+                height={700}
+                width={1200}
               />
             </div>
           </div>


### PR DESCRIPTION
**Issue** : Screenshot in home page is not rendered ([live](https://readme.so)).
**Cause** : Next/Image requires height and width (mandatory)
**Fix** : A simple addition of height and width to the Component will fix the problem

### Before :
![image](https://user-images.githubusercontent.com/32297581/235924651-762411eb-49d1-466a-a9bb-62ae19d008d7.png)

### After : 
![image](https://user-images.githubusercontent.com/32297581/235924928-13c26455-3aa1-4364-9a18-cbcde300561e.png)
