### PR TITLE
fix: replace color code placeholder path

### DIFF
--- a/data/section-templates-cn_CN.js
+++ b/data/section-templates-cn_CN.js
@@ -69,7 +69,7 @@ Clone 这个 project
     markdown: `
 ## 截图
 
-![App Screenshot](https://via.placeholder.com/468x300?text=App+Screenshot+Here)
+![App Screenshot](https://dummyimage.com/468x300?text=App+Screenshot+Here)
 
 `,
   },
@@ -438,10 +438,10 @@ Javascript, HTML, CSS...
 
 | 颜色             | 十六进制                                                                |
 | ----------------- | ------------------------------------------------------------------ |
-| 示例颜色 | ![#0a192f](https://via.placeholder.com/10/0a192f?text=+) #0a192f |
-| 示例颜色 | ![#f8f8f8](https://via.placeholder.com/10/f8f8f8?text=+) #f8f8f8 |
-| 示例颜色 | ![#00b48a](https://via.placeholder.com/10/00b48a?text=+) #00b48a |
-| 示例颜色 | ![#00d1a0](https://via.placeholder.com/10/00b48a?text=+) #00d1a0 |
+| 示例颜色 | ![#0a192f](https://dummyimage.com/10/0a192f/white?text=+) #0a192f |
+| 示例颜色 | ![#f8f8f8](https://dummyimage.com/10/f8f8f8/white?text=+) #f8f8f8 |
+| 示例颜色 | ![#00b48a](https://dummyimage.com/10/00b48a/white?text=+) #00b48a |
+| 示例颜色 | ![#00d1a0](https://dummyimage.com/10/00b48a/white?text=+) #00d1a0 |
 
 `,
   },

--- a/data/section-templates-en_EN.js
+++ b/data/section-templates-en_EN.js
@@ -69,7 +69,7 @@ Start the server
     markdown: `
 ## Screenshots
 
-![App Screenshot](https://via.placeholder.com/468x300?text=App+Screenshot+Here)
+![App Screenshot](https://dummyimage.com/468x300?text=App+Screenshot+Here)
 
 `,
   },
@@ -438,10 +438,10 @@ Javascript, HTML, CSS...
 
 | Color             | Hex                                                                |
 | ----------------- | ------------------------------------------------------------------ |
-| Example Color | ![#0a192f](https://via.placeholder.com/10/0a192f?text=+) #0a192f |
-| Example Color | ![#f8f8f8](https://via.placeholder.com/10/f8f8f8?text=+) #f8f8f8 |
-| Example Color | ![#00b48a](https://via.placeholder.com/10/00b48a?text=+) #00b48a |
-| Example Color | ![#00d1a0](https://via.placeholder.com/10/00b48a?text=+) #00d1a0 |
+| Example Color | ![#0a192f](https://dummyimage.com/10/0a192f/white?text=+) #0a192f |
+| Example Color | ![#f8f8f8](https://dummyimage.com/10/f8f8f8/white?text=+) #f8f8f8 |
+| Example Color | ![#00b48a](https://dummyimage.com/10/00b48a/white?text=+) #00b48a |
+| Example Color | ![#00d1a0](https://dummyimage.com/10/00d1a0/white?text=+)) #00d1a0 |
 
 `,
   },

--- a/data/section-templates-pt_BR.js
+++ b/data/section-templates-pt_BR.js
@@ -69,7 +69,7 @@ Inicie o servidor
     markdown: `
 ## Screenshots
 
-![App Screenshot](https://via.placeholder.com/468x300?text=App+Screenshot+Here)
+![App Screenshot](https://dummyimage.com/468x300?text=App+Screenshot+Here)
 
 `,
   },
@@ -438,10 +438,10 @@ Javascript, HTML, CSS...
 
 | Cor               | Hexadecimal                                                |
 | ----------------- | ---------------------------------------------------------------- |
-| Cor exemplo       | ![#0a192f](https://via.placeholder.com/10/0a192f?text=+) #0a192f |
-| Cor exemplo       | ![#f8f8f8](https://via.placeholder.com/10/f8f8f8?text=+) #f8f8f8 |
-| Cor exemplo       | ![#00b48a](https://via.placeholder.com/10/00b48a?text=+) #00b48a |
-| Cor exemplo       | ![#00d1a0](https://via.placeholder.com/10/00b48a?text=+) #00d1a0 |
+| Cor exemplo       | ![#0a192f](https://dummyimage.com/10/0a192f/white?text=+) #0a192f |
+| Cor exemplo       | ![#f8f8f8](https://dummyimage.com/10/f8f8f8/white?text=+) #f8f8f8 |
+| Cor exemplo       | ![#00b48a](https://dummyimage.com/10/00b48a/white?text=+) #00b48a |
+| Cor exemplo       | ![#00d1a0](https://dummyimage.com/10/00b48a/white?text=+) #00d1a0 |
 
 `,
   },

--- a/data/section-templates-tr_TR.js
+++ b/data/section-templates-tr_TR.js
@@ -69,7 +69,7 @@ Sunucuyu çalıştırın
     markdown: `
 ## Ekran Görüntüleri
 
-![Uygulama Ekran Görüntüsü](https://via.placeholder.com/468x300?text=App+Screenshot+Here)
+![Uygulama Ekran Görüntüsü](https://dummyimage.com/468x300?text=App+Screenshot+Here)
 
   `,
   },
@@ -366,9 +366,9 @@ Herhangi bir ek bilgi buraya gelir
 
 | Renk             | Hex                                                                |
 | ----------------- | ------------------------------------------------------------------ |
-| örnek renk | ![#0a192f](https://via.placeholder.com/10/0a192f?text=+) #0a192f |
-| örnek renk | ![#f8f8f8](https://via.placeholder.com/10/f8f8f8?text=+) #f8f8f8 |
-| örnek renk | ![#00b48a](https://via.placeholder.com/10/00b48a?text=+) #00b48a |
-| örnek renk | ![#00d1a0](https://via.placeholder.com/10/00b48a?text=+) #00d1a0 | `,
+| örnek renk | ![#0a192f](https://dummyimage.com/10/0a192f/white?text=+) #0a192f |
+| örnek renk | ![#f8f8f8](https://dummyimage.com/10/f8f8f8/white?text=+) #f8f8f8 |
+| örnek renk | ![#00b48a](https://dummyimage.com/10/00b48a/white?text=+) #00b48a |
+| örnek renk | ![#00d1a0](https://dummyimage.com/10/00b48a/white?text=+) #00d1a0 | `,
   },
 ]


### PR DESCRIPTION
This PR fixes #304 

The issue was due to `via.placeholder.com` is depreciated now. I replaced it with dummyimage.com.