### PR TITLE
feat: add sponsor section to multiple language templates

### DIFF
--- a/data/section-templates-cn_CN.js
+++ b/data/section-templates-cn_CN.js
@@ -445,4 +445,14 @@ Javascript, HTML, CSS...
 
 `,
   },
+  {
+    slug: 'sponsor',
+    name: '赞助商',
+    markdown: `
+## 赞助商
+如果您喜欢我的作品，可以成为赞助商来支持我。
+
+[![Tip in Crypto](https://tip.md/badge.svg)](https://tip.md/change-me)
+`,
+  },
 ]

--- a/data/section-templates-en_EN.js
+++ b/data/section-templates-en_EN.js
@@ -445,4 +445,14 @@ Javascript, HTML, CSS...
 
 `,
   },
+  {
+    slug: 'sponsor',
+    name: 'Sponsor',
+    markdown: `
+## Sponsor
+If you like my work, you can support me by becoming a sponsor.
+
+[![Tip in Crypto](https://tip.md/badge.svg)](https://tip.md/change-me)
+`,
+  },
 ]

--- a/data/section-templates-pt_BR.js
+++ b/data/section-templates-pt_BR.js
@@ -445,4 +445,14 @@ Javascript, HTML, CSS...
 
 `,
   },
+  {
+    slug: 'sponsor',
+    name: 'Patrocinador',
+    markdown: `
+## Patrocinador
+Se você gosta do meu trabalho, pode me apoiar se tornando um patrocinador.
+
+[![Tip in Crypto](https://tip.md/badge.svg)](https://tip.md/change-me)
+`,
+  },
 ]

--- a/data/section-templates-tr_TR.js
+++ b/data/section-templates-tr_TR.js
@@ -371,4 +371,14 @@ Herhangi bir ek bilgi buraya gelir
 | örnek renk | ![#00b48a](https://dummyimage.com/10/00b48a/white?text=+) #00b48a |
 | örnek renk | ![#00d1a0](https://dummyimage.com/10/00b48a/white?text=+) #00d1a0 | `,
   },
+  {
+    slug: 'sponsor',
+    name: 'Sponsor',
+    markdown: `
+## Sponsor
+Çalışmalarımı beğeniyorsanız, sponsor olarak beni destekleyebilirsiniz.
+
+[![Tip in Crypto](https://tip.md/badge.svg)](https://tip.md/change-me)
+`,
+  },
 ]


### PR DESCRIPTION
I haven't seen a section regarding sponsors for a git repository so I'm taking the opportunity to add one with the possibility of going through the [tip.md](https://www.tip.md/) service.

![image](https://github.com/user-attachments/assets/1ab1575b-c7f5-40ad-ae30-d3b7064c54bd)
