### PR TITLE
Allow raw HTML to be rendered (#218)

### DIFF
--- a/components/PreviewColumn.js
+++ b/components/PreviewColumn.js
@@ -25,6 +25,7 @@ export const PreviewColumn = ({ selectedSectionSlugs, getTemplate, selectedTab }
     >
       {showPreview ? (
         <ReactMarkdown
+          allowDangerousHtml
           plugins={[gfm]}
           children={markdown}
           renderers={{


### PR DESCRIPTION
This PR sets the `allowDangerousHtml` prop of `ReactMarkdown` to allow users to enter raw HTML and have it rendered properly on the preview:

<img width="1091" height="795" alt="Raw HTML Demo" src="https://github.com/user-attachments/assets/8e627e7c-ad7a-4803-a85a-ffe65942d8e9" />

It's worth noting that, while the prop suggests *allowing HTML is dangerous*, it's perfectly safe in this context. The raw HTML never leaves the browser and never reaches any server. The only place it is stored is the browser. In addition to that, I believe [`ReactMarkdown`](https://github.com/remarkjs/react-markdown) already makes sure that injected `<script>` tags don't get executed.